### PR TITLE
04-express-grunt-watch

### DIFF
--- a/04-express-grunt-watch/Dockerfile
+++ b/04-express-grunt-watch/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:0.10.38
 
 RUN apt-get update -qq && apt-get install -y build-essential
-RUN apt-get install -y ruby
+RUN apt-get install -y libssl-dev ruby
 RUN gem install sass
 
 RUN mkdir /src


### PR DESCRIPTION
This fixes this error in step 4: Run gem install sass
ERROR:  Loading command: install (LoadError)
	/usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so: symbol SSLv2_method, version OPENSSL_1.0.0 not defined in file libssl.so.1.0.0 with link time reference - /usr/lib/x86_64-linux-gnu/ruby/2.1.0/openssl.so
ERROR:  While executing gem ... (NoMethodError)
    undefined method `invoke_with_build_args' for nil:NilClass